### PR TITLE
Add optional key if the router is not the default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var chokidar = require('chokidar')
 var debug = require('debug')('express-reload')
 var path = require('path')
 
-module.exports = function(folder) {
+module.exports = function(folder, key) {
   debug('Folder to require and watch', folder)
   let rootFolder = folder
   if(folder.charAt(folder.length - path.sep.length) !== path.sep) {
@@ -26,6 +26,10 @@ module.exports = function(folder) {
   require(folder)
   return function(req, res, next) {
     debug('require hot reload')
-    require(folder)(req, res, next)
+    if (key) {
+      require(folder)[key](req, res, next)
+    } else {
+      require(folder)(req, res, next)
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,11 @@ var path = __dirname + '/project/'
 // or like this for a non index.js name
 var path = __dirname + '/project/server.js'
 
+// default export is the router
 app.use(reload(path))
+
+// or optional exported router by name
+app.use(reload(path, 'router')); // module.exports = { router, otherFn };       
 
 app.listen(9000, () => console.log('Listening on 9000'))
 


### PR DESCRIPTION
Allow us to use hot reloading when the router is not the default thing being exported.

Example:

```js
module.exports = { router, otherFn };
app.use(reload('./pathToFile', 'router'));
```