### PR TITLE
Update README with const, more examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,11 @@
-# express reload
+# express-reload
 
-Automaticly reload your express.js server without bringing down the server. This is really useful because it will hot reload instead of waiting for the whole node.js process to restart.
+[![npm version](https://badge.fury.io/js/express-reload.svg)](https://badge.fury.io/js/express-reload)
+
+Automatically reload your Express routers and middleware when their files change without restarting your Node process.
+
+## Disclaimer
+This is not intended for production use. Only use for development purposes. 
 
 ## Install
 
@@ -13,18 +18,20 @@ Find it on https://www.npmjs.com/package/express-reload
 ## Example
 
 ```js
-var express = require('express')
-var reload = require('express-reload')
-var app = express()
+const express = require('express')
+const reload = require('express-reload')
+const app = express()
 
-// path to reload
-// important should end with "/" if index.js
-var path = __dirname + '/project/'
-// or like this for a non index.js name
-var path = __dirname + '/project/server.js'
+// reload when the router is the default export
+app.use(reload('./path/to/router'))
 
-app.use(reload(path))
+// reload when the router is exported under another name
+// module.exports = { router, otherFn, otherFn2 }
+app.use(reload('./path/to/router', 'router'))
+
+// use on non-error middleware as well
+// function (req, res, next) {}
+app.use(reload('./path/to/middleware'))
 
 app.listen(9000, () => console.log('Listening on 9000'))
-
 ```


### PR DESCRIPTION
- Add NPM badge
- Update description
- Use newer `const`
- Add an example of use for middleware since this will work with any function that follows `(req, res, next)`
- Show example of different export name assuming #4 is accepted
- Remove tips about `file.js` vs `index` - `require` works without those